### PR TITLE
Drop bigquery datasets and content with sql

### DIFF
--- a/README_BigQuery_Drop_Operations.md
+++ b/README_BigQuery_Drop_Operations.md
@@ -1,0 +1,309 @@
+# BigQuery Drop Operations Guide
+
+This repository contains comprehensive examples and utilities for dropping datasets and their contents in Google BigQuery using SQL, Python, and shell scripts.
+
+## 📁 Files in this Repository
+
+1. **`bigquery_drop_operations.sql`** - Complete SQL reference for dropping BigQuery objects
+2. **`bigquery_drop_operations.py`** - Python utility class for programmatic drop operations
+3. **`bigquery_drop_operations.sh`** - Bash script for command-line drop operations
+4. **`README_BigQuery_Drop_Operations.md`** - This documentation file
+
+## ⚠️ IMPORTANT WARNINGS
+
+**These operations are DESTRUCTIVE and IRREVERSIBLE!**
+- Always backup important data before dropping
+- Dropped tables can only be restored within 7 days using time travel
+- Ensure you have proper permissions before executing drop operations
+- Test in a development environment first
+
+## 🔑 Required Permissions
+
+To perform drop operations, you need the following IAM permissions:
+- `bigquery.datasets.delete` - Drop datasets
+- `bigquery.tables.delete` - Drop tables and views
+- `bigquery.models.delete` - Drop ML models
+- `bigquery.routines.delete` - Drop functions and procedures
+
+## 📝 Quick SQL Examples
+
+### Drop a Single Table
+```sql
+DROP TABLE IF EXISTS `project-id.dataset_name.table_name`;
+```
+
+### Drop a View
+```sql
+DROP VIEW IF EXISTS `project-id.dataset_name.view_name`;
+```
+
+### Drop an Entire Dataset (Empty)
+```sql
+DROP SCHEMA IF EXISTS `project-id.dataset_name` RESTRICT;
+```
+
+### Drop an Entire Dataset with All Contents (CASCADE)
+```sql
+DROP SCHEMA IF EXISTS `project-id.dataset_name` CASCADE;
+```
+
+### Drop a Model
+```sql
+DROP MODEL IF EXISTS `project-id.dataset_name.model_name`;
+```
+
+### Drop a Function
+```sql
+DROP FUNCTION IF EXISTS `project-id.dataset_name.function_name`;
+```
+
+## 🐍 Python Usage
+
+### Installation
+```bash
+pip install google-cloud-bigquery
+```
+
+### Basic Usage
+```python
+from bigquery_drop_operations import BigQueryDropManager
+
+# Initialize
+manager = BigQueryDropManager("your-project-id")
+
+# Drop a table
+manager.drop_table("dataset_id", "table_id")
+
+# Drop all tables with a prefix
+manager.drop_tables_by_prefix("dataset_id", "temp_")
+
+# Drop entire dataset with contents
+manager.drop_dataset("dataset_id", delete_contents=True)
+
+# Backup before dropping
+manager.backup_table("source_dataset", "source_table", "backup_dataset")
+manager.drop_table("source_dataset", "source_table")
+```
+
+## 💻 Command-Line Usage (bq tool)
+
+### Prerequisites
+```bash
+# Install Google Cloud SDK
+curl https://sdk.cloud.google.com | bash
+
+# Authenticate
+gcloud auth login
+
+# Set project
+gcloud config set project YOUR_PROJECT_ID
+```
+
+### Basic Commands
+```bash
+# Drop a table
+bq rm -f -t project-id:dataset.table
+
+# Drop a view (same as table)
+bq rm -f -t project-id:dataset.view
+
+# Drop a model
+bq rm -f -m project-id:dataset.model
+
+# Drop a dataset (empty only)
+bq rm -f -d project-id:dataset
+
+# Drop a dataset with all contents
+bq rm -r -f -d project-id:dataset
+
+# Drop a routine
+bq rm -f --routine project-id:dataset.function_name
+```
+
+### Using the Shell Script
+```bash
+# Make executable
+chmod +x bigquery_drop_operations.sh
+
+# Run interactive menu
+./bigquery_drop_operations.sh
+
+# Or source and use functions
+source bigquery_drop_operations.sh
+drop_table "my_dataset" "my_table"
+```
+
+## 🔄 Best Practices
+
+### 1. Always Use IF EXISTS
+Prevents errors when objects don't exist:
+```sql
+DROP TABLE IF EXISTS `project.dataset.table`;
+```
+
+### 2. Create Backups First
+```sql
+-- Create backup
+CREATE TABLE `project.backup_dataset.table_backup_20241007`
+AS SELECT * FROM `project.dataset.table`;
+
+-- Verify backup
+SELECT COUNT(*) FROM `project.backup_dataset.table_backup_20241007`;
+
+-- Then drop original
+DROP TABLE IF EXISTS `project.dataset.table`;
+```
+
+### 3. Use CASCADE vs RESTRICT Appropriately
+- **CASCADE**: Drops dataset and all contents
+- **RESTRICT**: Only drops if dataset is empty (safer)
+
+### 4. Implement Safeguards
+```python
+# Always confirm destructive operations
+if input("Are you sure? (yes/no): ").lower() != "yes":
+    print("Operation cancelled")
+    exit()
+```
+
+### 5. Use Time Travel for Recovery
+If you accidentally drop a table, you can restore it within 7 days:
+```sql
+CREATE TABLE `project.dataset.recovered_table` AS 
+SELECT * FROM `project.dataset.dropped_table` 
+FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR);
+```
+
+## 📊 Dropping Specific Object Types
+
+### Partitioned Tables
+```sql
+-- Drop specific partitions
+DELETE FROM `project.dataset.partitioned_table`
+WHERE DATE(_PARTITIONTIME) = '2024-10-01';
+
+-- Drop entire partitioned table
+DROP TABLE IF EXISTS `project.dataset.partitioned_table`;
+```
+
+### External Tables
+```sql
+DROP EXTERNAL TABLE IF EXISTS `project.dataset.external_table`;
+```
+
+### Materialized Views
+```sql
+DROP MATERIALIZED VIEW IF EXISTS `project.dataset.materialized_view`;
+```
+
+### Search Indexes
+```sql
+DROP SEARCH INDEX IF EXISTS `index_name` ON `project.dataset.table`;
+```
+
+### Row Access Policies
+```sql
+DROP ALL ROW ACCESS POLICIES ON `project.dataset.table`;
+```
+
+## 🔍 Checking Before Dropping
+
+### List All Tables in Dataset
+```sql
+SELECT 
+  table_catalog,
+  table_schema,
+  table_name,
+  table_type,
+  creation_time
+FROM `project.dataset.INFORMATION_SCHEMA.TABLES`
+ORDER BY table_name;
+```
+
+### Check for Dependent Views
+```sql
+SELECT 
+  table_name AS dependent_view
+FROM `project.dataset.INFORMATION_SCHEMA.VIEWS`
+WHERE view_definition LIKE '%table_to_drop%';
+```
+
+## 🚀 Advanced Operations
+
+### Drop All Tables with Specific Pattern
+```sql
+DECLARE tables_to_drop ARRAY<STRING>;
+
+SET tables_to_drop = (
+  SELECT ARRAY_AGG(table_name)
+  FROM `project.dataset.INFORMATION_SCHEMA.TABLES`
+  WHERE table_name LIKE 'temp_%'
+);
+
+IF ARRAY_LENGTH(tables_to_drop) > 0 THEN
+  FOR i IN 0 .. ARRAY_LENGTH(tables_to_drop) - 1 DO
+    EXECUTE IMMEDIATE FORMAT(
+      'DROP TABLE IF EXISTS `project.dataset.%s`',
+      tables_to_drop[OFFSET(i)]
+    );
+  END FOR;
+END IF;
+```
+
+### Drop Tables Older Than N Days
+```sql
+DECLARE old_tables ARRAY<STRING>;
+
+SET old_tables = (
+  SELECT ARRAY_AGG(table_name)
+  FROM `project.dataset.INFORMATION_SCHEMA.TABLES`
+  WHERE creation_time < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
+);
+
+-- Drop each old table
+IF ARRAY_LENGTH(old_tables) > 0 THEN
+  FOR i IN 0 .. ARRAY_LENGTH(old_tables) - 1 DO
+    EXECUTE IMMEDIATE FORMAT(
+      'DROP TABLE IF EXISTS `project.dataset.%s`',
+      old_tables[OFFSET(i)]
+    );
+  END FOR;
+END IF;
+```
+
+## 🛡️ Safety Checklist
+
+Before dropping any BigQuery object:
+
+- [ ] Verified the correct project and dataset
+- [ ] Created backups of important data
+- [ ] Checked for dependent objects (views, procedures)
+- [ ] Confirmed with team members if shared resources
+- [ ] Documented the reason for dropping
+- [ ] Tested the operation in development first
+- [ ] Have recovery plan if needed
+
+## 📚 Additional Resources
+
+- [BigQuery DROP Statement Documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_table_statement)
+- [BigQuery Python Client Library](https://cloud.google.com/python/docs/reference/bigquery/latest)
+- [BigQuery Command-Line Tool Reference](https://cloud.google.com/bigquery/docs/bq-command-line-tool)
+- [BigQuery IAM Permissions](https://cloud.google.com/bigquery/docs/access-control)
+- [BigQuery Time Travel](https://cloud.google.com/bigquery/docs/time-travel)
+
+## 💡 Tips
+
+1. **Use Expiration Instead of Dropping**: For temporary tables, set expiration times instead of manually dropping
+2. **Partition Expiration**: Use partition expiration for time-series data
+3. **Soft Delete**: Consider renaming tables with a `_deleted` suffix instead of dropping
+4. **Audit Logs**: Enable audit logging to track who dropped what and when
+5. **Cost Optimization**: Dropping unused tables reduces storage costs immediately
+
+## ⚡ Performance Considerations
+
+- Dropping large tables is fast (metadata operation)
+- Dropping datasets with many objects can take time
+- Use parallel operations when dropping multiple objects
+- Consider using batch operations for better performance
+
+Remember: **Think twice, drop once!** Always ensure you're dropping the right object in the right environment.

--- a/bigquery_drop_operations.py
+++ b/bigquery_drop_operations.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+BigQuery Dataset and Content Dropping Operations using Python Client Library
+
+Requirements:
+    pip install google-cloud-bigquery
+"""
+
+from google.cloud import bigquery
+from google.cloud.exceptions import NotFound
+from typing import List, Optional
+import logging
+from datetime import datetime, timedelta
+
+# Set up logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+class BigQueryDropManager:
+    """Manages BigQuery drop operations for datasets and their contents."""
+    
+    def __init__(self, project_id: str):
+        """
+        Initialize the BigQuery client.
+        
+        Args:
+            project_id: GCP project ID
+        """
+        self.client = bigquery.Client(project=project_id)
+        self.project_id = project_id
+    
+    def drop_table(self, dataset_id: str, table_id: str, not_found_ok: bool = True) -> bool:
+        """
+        Drop a single table.
+        
+        Args:
+            dataset_id: Dataset containing the table
+            table_id: Table to drop
+            not_found_ok: If True, don't raise error if table doesn't exist
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        table_ref = f"{self.project_id}.{dataset_id}.{table_id}"
+        
+        try:
+            self.client.delete_table(table_ref, not_found_ok=not_found_ok)
+            logger.info(f"Dropped table: {table_ref}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to drop table {table_ref}: {e}")
+            return False
+    
+    def drop_view(self, dataset_id: str, view_id: str, not_found_ok: bool = True) -> bool:
+        """
+        Drop a view.
+        
+        Args:
+            dataset_id: Dataset containing the view
+            view_id: View to drop
+            not_found_ok: If True, don't raise error if view doesn't exist
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        # Views are deleted the same way as tables in the Python client
+        return self.drop_table(dataset_id, view_id, not_found_ok)
+    
+    def drop_model(self, dataset_id: str, model_id: str, not_found_ok: bool = True) -> bool:
+        """
+        Drop a machine learning model.
+        
+        Args:
+            dataset_id: Dataset containing the model
+            model_id: Model to drop
+            not_found_ok: If True, don't raise error if model doesn't exist
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        model_ref = f"{self.project_id}.{dataset_id}.{model_id}"
+        
+        try:
+            self.client.delete_model(model_ref, not_found_ok=not_found_ok)
+            logger.info(f"Dropped model: {model_ref}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to drop model {model_ref}: {e}")
+            return False
+    
+    def drop_routine(self, dataset_id: str, routine_id: str, not_found_ok: bool = True) -> bool:
+        """
+        Drop a routine (function or stored procedure).
+        
+        Args:
+            dataset_id: Dataset containing the routine
+            routine_id: Routine to drop
+            not_found_ok: If True, don't raise error if routine doesn't exist
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        routine_ref = f"{self.project_id}.{dataset_id}.{routine_id}"
+        
+        try:
+            self.client.delete_routine(routine_ref, not_found_ok=not_found_ok)
+            logger.info(f"Dropped routine: {routine_ref}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to drop routine {routine_ref}: {e}")
+            return False
+    
+    def drop_all_tables_in_dataset(self, dataset_id: str, include_views: bool = True) -> int:
+        """
+        Drop all tables (and optionally views) in a dataset.
+        
+        Args:
+            dataset_id: Dataset to clear
+            include_views: Also drop views if True
+        
+        Returns:
+            Number of tables/views dropped
+        """
+        dataset_ref = self.client.dataset(dataset_id)
+        dropped_count = 0
+        
+        try:
+            tables = self.client.list_tables(dataset_ref)
+            
+            for table in tables:
+                if table.table_type == "VIEW" and not include_views:
+                    logger.info(f"Skipping view: {table.table_id}")
+                    continue
+                
+                if self.drop_table(dataset_id, table.table_id):
+                    dropped_count += 1
+            
+            logger.info(f"Dropped {dropped_count} tables/views from dataset {dataset_id}")
+            return dropped_count
+            
+        except NotFound:
+            logger.error(f"Dataset {dataset_id} not found")
+            return 0
+        except Exception as e:
+            logger.error(f"Error dropping tables in dataset {dataset_id}: {e}")
+            return dropped_count
+    
+    def drop_tables_by_prefix(self, dataset_id: str, prefix: str) -> int:
+        """
+        Drop all tables with a specific prefix.
+        
+        Args:
+            dataset_id: Dataset containing the tables
+            prefix: Table name prefix to match
+        
+        Returns:
+            Number of tables dropped
+        """
+        dataset_ref = self.client.dataset(dataset_id)
+        dropped_count = 0
+        
+        try:
+            tables = self.client.list_tables(dataset_ref)
+            
+            for table in tables:
+                if table.table_id.startswith(prefix):
+                    if self.drop_table(dataset_id, table.table_id):
+                        dropped_count += 1
+            
+            logger.info(f"Dropped {dropped_count} tables with prefix '{prefix}'")
+            return dropped_count
+            
+        except Exception as e:
+            logger.error(f"Error dropping tables by prefix: {e}")
+            return dropped_count
+    
+    def drop_old_tables(self, dataset_id: str, days_old: int) -> int:
+        """
+        Drop tables older than specified number of days.
+        
+        Args:
+            dataset_id: Dataset containing the tables
+            days_old: Age threshold in days
+        
+        Returns:
+            Number of tables dropped
+        """
+        dataset_ref = self.client.dataset(dataset_id)
+        dropped_count = 0
+        cutoff_time = datetime.now() - timedelta(days=days_old)
+        
+        try:
+            tables = self.client.list_tables(dataset_ref)
+            
+            for table in tables:
+                table_full = self.client.get_table(f"{self.project_id}.{dataset_id}.{table.table_id}")
+                
+                if table_full.created and table_full.created.replace(tzinfo=None) < cutoff_time:
+                    logger.info(f"Table {table.table_id} created on {table_full.created} - dropping")
+                    if self.drop_table(dataset_id, table.table_id):
+                        dropped_count += 1
+            
+            logger.info(f"Dropped {dropped_count} tables older than {days_old} days")
+            return dropped_count
+            
+        except Exception as e:
+            logger.error(f"Error dropping old tables: {e}")
+            return dropped_count
+    
+    def drop_dataset(self, dataset_id: str, delete_contents: bool = False, 
+                    not_found_ok: bool = True) -> bool:
+        """
+        Drop an entire dataset.
+        
+        Args:
+            dataset_id: Dataset to drop
+            delete_contents: If True, delete all tables/views first (CASCADE)
+            not_found_ok: If True, don't raise error if dataset doesn't exist
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        dataset_ref = self.client.dataset(dataset_id)
+        
+        try:
+            self.client.delete_dataset(
+                dataset_ref,
+                delete_contents=delete_contents,
+                not_found_ok=not_found_ok
+            )
+            logger.info(f"Dropped dataset: {dataset_id}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to drop dataset {dataset_id}: {e}")
+            return False
+    
+    def backup_table(self, source_dataset: str, source_table: str, 
+                    backup_dataset: str, backup_table: Optional[str] = None) -> bool:
+        """
+        Create a backup of a table before dropping.
+        
+        Args:
+            source_dataset: Source dataset
+            source_table: Source table to backup
+            backup_dataset: Destination dataset for backup
+            backup_table: Backup table name (defaults to source_table_backup_YYYYMMDD)
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        if backup_table is None:
+            backup_table = f"{source_table}_backup_{datetime.now().strftime('%Y%m%d')}"
+        
+        source_ref = f"{self.project_id}.{source_dataset}.{source_table}"
+        backup_ref = f"{self.project_id}.{backup_dataset}.{backup_table}"
+        
+        try:
+            query = f"CREATE TABLE `{backup_ref}` AS SELECT * FROM `{source_ref}`"
+            query_job = self.client.query(query)
+            query_job.result()  # Wait for the query to complete
+            
+            logger.info(f"Created backup: {backup_ref}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to backup table: {e}")
+            return False
+    
+    def execute_drop_sql(self, sql: str) -> bool:
+        """
+        Execute a custom DROP SQL statement.
+        
+        Args:
+            sql: SQL DROP statement to execute
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            query_job = self.client.query(sql)
+            query_job.result()  # Wait for the query to complete
+            logger.info(f"Executed SQL: {sql}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to execute SQL: {e}")
+            return False
+    
+    def list_dataset_contents(self, dataset_id: str) -> dict:
+        """
+        List all contents of a dataset.
+        
+        Args:
+            dataset_id: Dataset to inspect
+        
+        Returns:
+            Dictionary with lists of tables, views, models, and routines
+        """
+        contents = {
+            "tables": [],
+            "views": [],
+            "models": [],
+            "routines": []
+        }
+        
+        try:
+            dataset_ref = self.client.dataset(dataset_id)
+            
+            # List tables and views
+            tables = self.client.list_tables(dataset_ref)
+            for table in tables:
+                if table.table_type == "VIEW":
+                    contents["views"].append(table.table_id)
+                else:
+                    contents["tables"].append(table.table_id)
+            
+            # List models
+            models = self.client.list_models(dataset_ref)
+            for model in models:
+                contents["models"].append(model.model_id)
+            
+            # List routines
+            routines = self.client.list_routines(dataset_ref)
+            for routine in routines:
+                contents["routines"].append(routine.routine_id)
+            
+            return contents
+            
+        except Exception as e:
+            logger.error(f"Error listing dataset contents: {e}")
+            return contents
+
+
+def main():
+    """Example usage of the BigQueryDropManager class."""
+    
+    # Initialize the manager
+    project_id = "your-project-id"
+    manager = BigQueryDropManager(project_id)
+    
+    # Example 1: Drop a single table
+    manager.drop_table("analytics_dataset", "temp_table")
+    
+    # Example 2: Drop all tables with a prefix
+    manager.drop_tables_by_prefix("analytics_dataset", "temp_")
+    
+    # Example 3: Drop tables older than 30 days
+    manager.drop_old_tables("analytics_dataset", days_old=30)
+    
+    # Example 4: Backup and drop a table
+    manager.backup_table(
+        source_dataset="production",
+        source_table="important_data",
+        backup_dataset="backups"
+    )
+    manager.drop_table("production", "important_data")
+    
+    # Example 5: List dataset contents before dropping
+    contents = manager.list_dataset_contents("test_dataset")
+    print(f"Dataset contents: {contents}")
+    
+    # Example 6: Drop all contents in a dataset
+    manager.drop_all_tables_in_dataset("test_dataset")
+    
+    # Example 7: Drop entire dataset with all contents (CASCADE)
+    manager.drop_dataset("test_dataset", delete_contents=True)
+    
+    # Example 8: Execute custom DROP SQL
+    manager.execute_drop_sql(
+        "DROP TABLE IF EXISTS `your-project-id.dataset_name.table_name`"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bigquery_drop_operations.sh
+++ b/bigquery_drop_operations.sh
@@ -1,0 +1,444 @@
+#!/bin/bash
+
+# BigQuery Drop Operations using bq Command-Line Tool
+# =====================================================
+#
+# Prerequisites:
+# - Google Cloud SDK installed (gcloud)
+# - BigQuery command-line tool (bq) installed
+# - Authenticated with: gcloud auth login
+# - Project set: gcloud config set project PROJECT_ID
+
+# Set your project ID
+PROJECT_ID="your-project-id"
+DATASET_ID="your-dataset"
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored messages
+print_message() {
+    local color=$1
+    local message=$2
+    echo -e "${color}${message}${NC}"
+}
+
+# Function to confirm destructive operations
+confirm_action() {
+    local action=$1
+    read -p "Are you sure you want to ${action}? (yes/no): " confirm
+    if [[ $confirm != "yes" ]]; then
+        print_message $YELLOW "Operation cancelled."
+        return 1
+    fi
+    return 0
+}
+
+# ============================================
+# DROP INDIVIDUAL TABLES
+# ============================================
+
+drop_table() {
+    local dataset=$1
+    local table=$2
+    
+    print_message $YELLOW "Dropping table: ${dataset}.${table}"
+    
+    # Using --force flag to skip confirmation
+    bq rm -f -t "${PROJECT_ID}:${dataset}.${table}"
+    
+    if [ $? -eq 0 ]; then
+        print_message $GREEN "Successfully dropped table: ${table}"
+    else
+        print_message $RED "Failed to drop table: ${table}"
+    fi
+}
+
+# ============================================
+# DROP VIEWS
+# ============================================
+
+drop_view() {
+    local dataset=$1
+    local view=$2
+    
+    print_message $YELLOW "Dropping view: ${dataset}.${view}"
+    
+    # Views are dropped the same way as tables
+    bq rm -f -t "${PROJECT_ID}:${dataset}.${view}"
+    
+    if [ $? -eq 0 ]; then
+        print_message $GREEN "Successfully dropped view: ${view}"
+    else
+        print_message $RED "Failed to drop view: ${view}"
+    fi
+}
+
+# ============================================
+# DROP MODELS
+# ============================================
+
+drop_model() {
+    local dataset=$1
+    local model=$2
+    
+    print_message $YELLOW "Dropping model: ${dataset}.${model}"
+    
+    bq rm -f -m "${PROJECT_ID}:${dataset}.${model}"
+    
+    if [ $? -eq 0 ]; then
+        print_message $GREEN "Successfully dropped model: ${model}"
+    else
+        print_message $RED "Failed to drop model: ${model}"
+    fi
+}
+
+# ============================================
+# DROP ROUTINES (Functions/Procedures)
+# ============================================
+
+drop_routine() {
+    local dataset=$1
+    local routine=$2
+    
+    print_message $YELLOW "Dropping routine: ${dataset}.${routine}"
+    
+    bq rm -f --routine "${PROJECT_ID}:${dataset}.${routine}"
+    
+    if [ $? -eq 0 ]; then
+        print_message $GREEN "Successfully dropped routine: ${routine}"
+    else
+        print_message $RED "Failed to drop routine: ${routine}"
+    fi
+}
+
+# ============================================
+# DROP ALL TABLES IN A DATASET
+# ============================================
+
+drop_all_tables_in_dataset() {
+    local dataset=$1
+    
+    if ! confirm_action "drop ALL tables in dataset ${dataset}"; then
+        return 1
+    fi
+    
+    print_message $YELLOW "Fetching all tables in dataset: ${dataset}"
+    
+    # List all tables and iterate through them
+    tables=$(bq ls -t --max_results=10000 --format=json "${PROJECT_ID}:${dataset}" | \
+             jq -r '.[] | select(.type=="TABLE") | .tableReference.tableId')
+    
+    if [ -z "$tables" ]; then
+        print_message $YELLOW "No tables found in dataset: ${dataset}"
+        return 0
+    fi
+    
+    for table in $tables; do
+        drop_table "$dataset" "$table"
+    done
+}
+
+# ============================================
+# DROP ALL VIEWS IN A DATASET
+# ============================================
+
+drop_all_views_in_dataset() {
+    local dataset=$1
+    
+    if ! confirm_action "drop ALL views in dataset ${dataset}"; then
+        return 1
+    fi
+    
+    print_message $YELLOW "Fetching all views in dataset: ${dataset}"
+    
+    # List all views and iterate through them
+    views=$(bq ls -t --max_results=10000 --format=json "${PROJECT_ID}:${dataset}" | \
+            jq -r '.[] | select(.type=="VIEW") | .tableReference.tableId')
+    
+    if [ -z "$views" ]; then
+        print_message $YELLOW "No views found in dataset: ${dataset}"
+        return 0
+    fi
+    
+    for view in $views; do
+        drop_view "$dataset" "$view"
+    done
+}
+
+# ============================================
+# DROP TABLES BY PREFIX
+# ============================================
+
+drop_tables_by_prefix() {
+    local dataset=$1
+    local prefix=$2
+    
+    print_message $YELLOW "Dropping tables with prefix '${prefix}' in dataset: ${dataset}"
+    
+    # List tables with specific prefix
+    tables=$(bq ls -t --max_results=10000 --format=json "${PROJECT_ID}:${dataset}" | \
+             jq -r --arg prefix "$prefix" '.[] | select(.tableReference.tableId | startswith($prefix)) | .tableReference.tableId')
+    
+    if [ -z "$tables" ]; then
+        print_message $YELLOW "No tables found with prefix: ${prefix}"
+        return 0
+    fi
+    
+    for table in $tables; do
+        drop_table "$dataset" "$table"
+    done
+}
+
+# ============================================
+# DROP ENTIRE DATASET
+# ============================================
+
+drop_dataset() {
+    local dataset=$1
+    local recursive=$2  # true or false
+    
+    if ! confirm_action "drop entire dataset ${dataset}"; then
+        return 1
+    fi
+    
+    print_message $YELLOW "Dropping dataset: ${dataset}"
+    
+    if [ "$recursive" == "true" ]; then
+        # Drop dataset and all its contents
+        bq rm -r -f -d "${PROJECT_ID}:${dataset}"
+    else
+        # Drop dataset only if empty
+        bq rm -f -d "${PROJECT_ID}:${dataset}"
+    fi
+    
+    if [ $? -eq 0 ]; then
+        print_message $GREEN "Successfully dropped dataset: ${dataset}"
+    else
+        print_message $RED "Failed to drop dataset: ${dataset}"
+    fi
+}
+
+# ============================================
+# BACKUP TABLE BEFORE DROPPING
+# ============================================
+
+backup_and_drop_table() {
+    local source_dataset=$1
+    local source_table=$2
+    local backup_dataset=$3
+    
+    local backup_table="${source_table}_backup_$(date +%Y%m%d_%H%M%S)"
+    
+    print_message $YELLOW "Creating backup of table: ${source_table}"
+    
+    # Create backup using bq cp
+    bq cp -f "${PROJECT_ID}:${source_dataset}.${source_table}" \
+             "${PROJECT_ID}:${backup_dataset}.${backup_table}"
+    
+    if [ $? -eq 0 ]; then
+        print_message $GREEN "Backup created: ${backup_dataset}.${backup_table}"
+        
+        # Now drop the original table
+        drop_table "$source_dataset" "$source_table"
+    else
+        print_message $RED "Failed to create backup. Original table not dropped."
+    fi
+}
+
+# ============================================
+# DROP OLD TABLES (Older than N days)
+# ============================================
+
+drop_old_tables() {
+    local dataset=$1
+    local days_old=$2
+    
+    if ! confirm_action "drop tables older than ${days_old} days in dataset ${dataset}"; then
+        return 1
+    fi
+    
+    print_message $YELLOW "Finding tables older than ${days_old} days..."
+    
+    # Calculate timestamp in milliseconds for comparison
+    local cutoff_timestamp=$(($(date -d "${days_old} days ago" +%s) * 1000))
+    
+    # Get all tables with their creation time
+    tables_json=$(bq ls -t --max_results=10000 --format=json "${PROJECT_ID}:${dataset}")
+    
+    # Parse and filter old tables
+    old_tables=$(echo "$tables_json" | jq -r --arg cutoff "$cutoff_timestamp" \
+                 '.[] | select(.creationTime < ($cutoff | tonumber)) | .tableReference.tableId')
+    
+    if [ -z "$old_tables" ]; then
+        print_message $YELLOW "No tables older than ${days_old} days found"
+        return 0
+    fi
+    
+    for table in $old_tables; do
+        drop_table "$dataset" "$table"
+    done
+}
+
+# ============================================
+# LIST DATASET CONTENTS
+# ============================================
+
+list_dataset_contents() {
+    local dataset=$1
+    
+    print_message $GREEN "Contents of dataset: ${dataset}"
+    
+    echo -e "\n${YELLOW}Tables:${NC}"
+    bq ls -t --max_results=10000 "${PROJECT_ID}:${dataset}" | grep TABLE || echo "No tables found"
+    
+    echo -e "\n${YELLOW}Views:${NC}"
+    bq ls -t --max_results=10000 "${PROJECT_ID}:${dataset}" | grep VIEW || echo "No views found"
+    
+    echo -e "\n${YELLOW}Models:${NC}"
+    bq ls -m --max_results=10000 "${PROJECT_ID}:${dataset}" 2>/dev/null || echo "No models found"
+    
+    echo -e "\n${YELLOW}Routines:${NC}"
+    bq ls --routines --max_results=10000 "${PROJECT_ID}:${dataset}" 2>/dev/null || echo "No routines found"
+}
+
+# ============================================
+# EXECUTE DROP SQL
+# ============================================
+
+execute_drop_sql() {
+    local sql=$1
+    
+    print_message $YELLOW "Executing SQL: ${sql}"
+    
+    bq query --use_legacy_sql=false "$sql"
+    
+    if [ $? -eq 0 ]; then
+        print_message $GREEN "SQL executed successfully"
+    else
+        print_message $RED "SQL execution failed"
+    fi
+}
+
+# ============================================
+# INTERACTIVE MENU
+# ============================================
+
+show_menu() {
+    echo -e "\n${GREEN}=== BigQuery Drop Operations Menu ===${NC}"
+    echo "1. Drop a single table"
+    echo "2. Drop a single view"
+    echo "3. Drop a model"
+    echo "4. Drop a routine"
+    echo "5. Drop all tables in a dataset"
+    echo "6. Drop all views in a dataset"
+    echo "7. Drop tables by prefix"
+    echo "8. Drop entire dataset (empty)"
+    echo "9. Drop entire dataset (with contents)"
+    echo "10. Backup and drop table"
+    echo "11. Drop old tables"
+    echo "12. List dataset contents"
+    echo "13. Execute custom DROP SQL"
+    echo "14. Exit"
+}
+
+# ============================================
+# MAIN SCRIPT
+# ============================================
+
+main() {
+    # Check if bq command is available
+    if ! command -v bq &> /dev/null; then
+        print_message $RED "Error: bq command not found. Please install Google Cloud SDK."
+        exit 1
+    fi
+    
+    # Check if jq is available (for JSON parsing)
+    if ! command -v jq &> /dev/null; then
+        print_message $YELLOW "Warning: jq not found. Some features may not work properly."
+        print_message $YELLOW "Install with: sudo apt-get install jq (or appropriate package manager)"
+    fi
+    
+    while true; do
+        show_menu
+        read -p "Select an option (1-14): " choice
+        
+        case $choice in
+            1)
+                read -p "Enter dataset name: " dataset
+                read -p "Enter table name: " table
+                drop_table "$dataset" "$table"
+                ;;
+            2)
+                read -p "Enter dataset name: " dataset
+                read -p "Enter view name: " view
+                drop_view "$dataset" "$view"
+                ;;
+            3)
+                read -p "Enter dataset name: " dataset
+                read -p "Enter model name: " model
+                drop_model "$dataset" "$model"
+                ;;
+            4)
+                read -p "Enter dataset name: " dataset
+                read -p "Enter routine name: " routine
+                drop_routine "$dataset" "$routine"
+                ;;
+            5)
+                read -p "Enter dataset name: " dataset
+                drop_all_tables_in_dataset "$dataset"
+                ;;
+            6)
+                read -p "Enter dataset name: " dataset
+                drop_all_views_in_dataset "$dataset"
+                ;;
+            7)
+                read -p "Enter dataset name: " dataset
+                read -p "Enter table prefix: " prefix
+                drop_tables_by_prefix "$dataset" "$prefix"
+                ;;
+            8)
+                read -p "Enter dataset name: " dataset
+                drop_dataset "$dataset" "false"
+                ;;
+            9)
+                read -p "Enter dataset name: " dataset
+                drop_dataset "$dataset" "true"
+                ;;
+            10)
+                read -p "Enter source dataset: " source_dataset
+                read -p "Enter source table: " source_table
+                read -p "Enter backup dataset: " backup_dataset
+                backup_and_drop_table "$source_dataset" "$source_table" "$backup_dataset"
+                ;;
+            11)
+                read -p "Enter dataset name: " dataset
+                read -p "Enter age threshold (days): " days
+                drop_old_tables "$dataset" "$days"
+                ;;
+            12)
+                read -p "Enter dataset name: " dataset
+                list_dataset_contents "$dataset"
+                ;;
+            13)
+                read -p "Enter DROP SQL statement: " sql
+                execute_drop_sql "$sql"
+                ;;
+            14)
+                print_message $GREEN "Exiting..."
+                exit 0
+                ;;
+            *)
+                print_message $RED "Invalid option. Please try again."
+                ;;
+        esac
+    done
+}
+
+# Run main function if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/bigquery_drop_operations.sql
+++ b/bigquery_drop_operations.sql
@@ -1,0 +1,291 @@
+-- BigQuery SQL Commands for Dropping Datasets and Content
+-- =========================================================
+
+-- IMPORTANT NOTES:
+-- 1. These operations are IRREVERSIBLE. Always backup important data before dropping.
+-- 2. You need appropriate permissions (bigquery.datasets.delete, bigquery.tables.delete)
+-- 3. Dataset names are case-sensitive in BigQuery
+
+-- ===========================================
+-- DROPPING INDIVIDUAL TABLES
+-- ===========================================
+
+-- Drop a single table
+DROP TABLE IF EXISTS `project_id.dataset_name.table_name`;
+
+-- Example:
+DROP TABLE IF EXISTS `my-project.analytics_dataset.user_events`;
+
+-- Drop multiple tables (execute separately)
+DROP TABLE IF EXISTS `my-project.analytics_dataset.table1`;
+DROP TABLE IF EXISTS `my-project.analytics_dataset.table2`;
+DROP TABLE IF EXISTS `my-project.analytics_dataset.table3`;
+
+-- ===========================================
+-- DROPPING VIEWS
+-- ===========================================
+
+-- Drop a view
+DROP VIEW IF EXISTS `project_id.dataset_name.view_name`;
+
+-- Example:
+DROP VIEW IF EXISTS `my-project.analytics_dataset.monthly_summary_view`;
+
+-- ===========================================
+-- DROPPING MATERIALIZED VIEWS
+-- ===========================================
+
+-- Drop a materialized view
+DROP MATERIALIZED VIEW IF EXISTS `project_id.dataset_name.materialized_view_name`;
+
+-- Example:
+DROP MATERIALIZED VIEW IF EXISTS `my-project.analytics_dataset.daily_aggregates`;
+
+-- ===========================================
+-- DROPPING EXTERNAL TABLES
+-- ===========================================
+
+-- Drop an external table
+DROP EXTERNAL TABLE IF EXISTS `project_id.dataset_name.external_table_name`;
+
+-- Example:
+DROP EXTERNAL TABLE IF EXISTS `my-project.analytics_dataset.gcs_data`;
+
+-- ===========================================
+-- DROPPING MODELS (ML Models)
+-- ===========================================
+
+-- Drop a machine learning model
+DROP MODEL IF EXISTS `project_id.dataset_name.model_name`;
+
+-- Example:
+DROP MODEL IF EXISTS `my-project.ml_dataset.customer_churn_model`;
+
+-- ===========================================
+-- DROPPING FUNCTIONS
+-- ===========================================
+
+-- Drop a user-defined function (UDF)
+DROP FUNCTION IF EXISTS `project_id.dataset_name.function_name`;
+
+-- Example:
+DROP FUNCTION IF EXISTS `my-project.analytics_dataset.calculate_revenue`;
+
+-- Drop a table function
+DROP TABLE FUNCTION IF EXISTS `project_id.dataset_name.table_function_name`;
+
+-- ===========================================
+-- DROPPING PROCEDURES
+-- ===========================================
+
+-- Drop a stored procedure
+DROP PROCEDURE IF EXISTS `project_id.dataset_name.procedure_name`;
+
+-- Example:
+DROP PROCEDURE IF EXISTS `my-project.analytics_dataset.daily_etl_process`;
+
+-- ===========================================
+-- DROPPING SEARCH INDEXES
+-- ===========================================
+
+-- Drop a search index
+DROP SEARCH INDEX IF EXISTS `index_name` ON `project_id.dataset_name.table_name`;
+
+-- Example:
+DROP SEARCH INDEX IF EXISTS `text_search_idx` ON `my-project.analytics_dataset.documents`;
+
+-- ===========================================
+-- DROPPING ROW ACCESS POLICIES
+-- ===========================================
+
+-- Drop a row access policy
+DROP ROW ACCESS POLICY IF EXISTS `policy_name` ON `project_id.dataset_name.table_name`;
+
+-- Drop all row access policies on a table
+DROP ALL ROW ACCESS POLICIES ON `project_id.dataset_name.table_name`;
+
+-- ===========================================
+-- DROPPING ENTIRE SCHEMAS (DATASETS)
+-- ===========================================
+
+-- Drop an entire dataset/schema with CASCADE (removes all content)
+DROP SCHEMA IF EXISTS `project_id.dataset_name` CASCADE;
+
+-- Example:
+DROP SCHEMA IF EXISTS `my-project.temp_dataset` CASCADE;
+
+-- Drop a dataset without CASCADE (fails if dataset contains objects)
+DROP SCHEMA IF EXISTS `project_id.dataset_name` RESTRICT;
+
+-- Note: SCHEMA and DATASET are synonymous in BigQuery
+DROP DATASET IF EXISTS `project_id.dataset_name` CASCADE;
+
+-- ===========================================
+-- PROGRAMMATIC APPROACH TO DROP ALL TABLES IN A DATASET
+-- ===========================================
+
+-- You can use a script to drop all tables in a dataset
+-- This example uses BigQuery's procedural language
+
+DECLARE table_list ARRAY<STRING>;
+
+-- Get list of all tables in the dataset
+SET table_list = (
+  SELECT ARRAY_AGG(table_name)
+  FROM `project_id.dataset_name.INFORMATION_SCHEMA.TABLES`
+  WHERE table_type = 'BASE TABLE'
+);
+
+-- Loop through and drop each table
+IF ARRAY_LENGTH(table_list) > 0 THEN
+  FOR i IN 0 .. ARRAY_LENGTH(table_list) - 1 DO
+    EXECUTE IMMEDIATE FORMAT(
+      'DROP TABLE IF EXISTS `project_id.dataset_name.%s`',
+      table_list[OFFSET(i)]
+    );
+  END FOR;
+END IF;
+
+-- ===========================================
+-- USING INFORMATION SCHEMA TO IDENTIFY OBJECTS
+-- ===========================================
+
+-- List all tables in a dataset before dropping
+SELECT 
+  table_catalog,
+  table_schema,
+  table_name,
+  table_type,
+  creation_time
+FROM `project_id.dataset_name.INFORMATION_SCHEMA.TABLES`
+ORDER BY table_name;
+
+-- List all views in a dataset
+SELECT 
+  table_name
+FROM `project_id.dataset_name.INFORMATION_SCHEMA.VIEWS`
+ORDER BY table_name;
+
+-- List all routines (functions and procedures)
+SELECT 
+  routine_name,
+  routine_type
+FROM `project_id.dataset_name.INFORMATION_SCHEMA.ROUTINES`
+ORDER BY routine_name;
+
+-- ===========================================
+-- SAFE DROPPING PATTERN WITH BACKUP
+-- ===========================================
+
+-- 1. First, create a backup of important tables
+CREATE TABLE `project_id.backup_dataset.table_backup_20241007`
+AS SELECT * FROM `project_id.dataset_name.important_table`;
+
+-- 2. Verify backup
+SELECT COUNT(*) as row_count 
+FROM `project_id.backup_dataset.table_backup_20241007`;
+
+-- 3. Then drop the original
+DROP TABLE IF EXISTS `project_id.dataset_name.important_table`;
+
+-- ===========================================
+-- CONDITIONAL DROPPING BASED ON AGE
+-- ===========================================
+
+-- Drop tables older than 30 days (requires procedural SQL)
+DECLARE tables_to_drop ARRAY<STRING>;
+
+SET tables_to_drop = (
+  SELECT ARRAY_AGG(table_name)
+  FROM `project_id.dataset_name.INFORMATION_SCHEMA.TABLES`
+  WHERE table_type = 'BASE TABLE'
+    AND creation_time < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
+);
+
+IF ARRAY_LENGTH(tables_to_drop) > 0 THEN
+  FOR i IN 0 .. ARRAY_LENGTH(tables_to_drop) - 1 DO
+    EXECUTE IMMEDIATE FORMAT(
+      'DROP TABLE IF EXISTS `project_id.dataset_name.%s`',
+      tables_to_drop[OFFSET(i)]
+    );
+  END FOR;
+END IF;
+
+-- ===========================================
+-- IMPORTANT CONSIDERATIONS
+-- ===========================================
+
+/*
+1. Permissions Required:
+   - bigquery.datasets.delete - to drop datasets
+   - bigquery.tables.delete - to drop tables
+   - bigquery.models.delete - to drop models
+   - bigquery.routines.delete - to drop functions/procedures
+
+2. CASCADE vs RESTRICT:
+   - CASCADE: Drops the dataset and all its contents
+   - RESTRICT: Only drops the dataset if it's empty (default behavior)
+
+3. IF EXISTS clause:
+   - Prevents errors if the object doesn't exist
+   - Recommended for production scripts
+
+4. Recovery:
+   - Dropped tables can be restored within 7 days using time travel
+   - Example: CREATE TABLE recovered_table AS 
+             SELECT * FROM `project.dataset.table` 
+             FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)
+
+5. Best Practices:
+   - Always use IF EXISTS to avoid errors
+   - Create backups before dropping important data
+   - Use meaningful naming for backup tables
+   - Test drop commands in a development environment first
+   - Document the reason for dropping in your change management system
+   
+6. Alternative to Dropping:
+   - Consider using table expiration for temporary tables
+   - Use partitioning with partition expiration for time-based data
+   - Rename tables instead of dropping if you might need them later
+*/
+
+-- ===========================================
+-- DROPPING PARTITIONED TABLES
+-- ===========================================
+
+-- Drop specific partitions (for partitioned tables)
+DELETE FROM `project_id.dataset_name.partitioned_table`
+WHERE DATE(_PARTITIONTIME) = '2024-10-01';
+
+-- Drop entire partitioned table
+DROP TABLE IF EXISTS `project_id.dataset_name.partitioned_table`;
+
+-- ===========================================
+-- DROPPING WITH DEPENDENCIES CHECK
+-- ===========================================
+
+-- Check for dependent views before dropping a table
+SELECT 
+  table_name AS dependent_view
+FROM `project_id.dataset_name.INFORMATION_SCHEMA.VIEWS`
+WHERE view_definition LIKE '%table_to_drop%';
+
+-- ===========================================
+-- BATCH OPERATIONS USING EXECUTE IMMEDIATE
+-- ===========================================
+
+-- Example: Drop all tables with a specific prefix
+DECLARE sql_statement STRING;
+FOR record IN (
+  SELECT table_name
+  FROM `project_id.dataset_name.INFORMATION_SCHEMA.TABLES`
+  WHERE table_name LIKE 'temp_%'
+    AND table_type = 'BASE TABLE'
+)
+DO
+  SET sql_statement = FORMAT(
+    'DROP TABLE IF EXISTS `project_id.dataset_name.%s`',
+    record.table_name
+  );
+  EXECUTE IMMEDIATE sql_statement;
+END FOR;


### PR DESCRIPTION
Add a comprehensive guide for BigQuery drop operations (datasets, tables, views, etc.) using SQL, Python, and shell scripts to provide a complete solution for safe data management.

The user requested how to drop datasets and their contents in BigQuery using SQL. To provide a robust and practical solution, the response was expanded to include programmatic (Python) and command-line (shell script with `bq` tool) approaches, along with a detailed README covering best practices, permissions, and recovery options. This holistic approach aims to empower users with various tools and knowledge for managing destructive BigQuery operations safely.

---
<a href="https://cursor.com/background-agent?bcId=bc-e21462f1-2250-40e4-b43a-56a94f226f22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e21462f1-2250-40e4-b43a-56a94f226f22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

