### PR TITLE
Restrict bigquery dataset access by user

### DIFF
--- a/README_BIGQUERY_ACCESS.md
+++ b/README_BIGQUERY_ACCESS.md
@@ -1,0 +1,454 @@
+# BigQuery Dataset Access Control Guide
+
+## Overview
+
+This guide provides comprehensive solutions for restricting BigQuery dataset access in Google Cloud Platform, ensuring users can only see and access their own datasets while preventing unauthorized access to other datasets.
+
+## Problem Statement
+
+In a single Google Cloud project with multiple BigQuery datasets, you need to:
+- Restrict users from seeing datasets they don't own
+- Allow users to access only their designated datasets
+- Maintain proper security and isolation between different users' data
+
+## Solutions Provided
+
+### 1. Python Script (`bigquery_dataset_access_manager.py`)
+
+A comprehensive Python tool for managing BigQuery dataset permissions programmatically.
+
+#### Installation
+
+```bash
+# Install required dependencies
+pip install google-cloud-bigquery
+
+# Set up authentication
+export GOOGLE_APPLICATION_CREDENTIALS="path/to/service-account-key.json"
+# OR use gcloud auth
+gcloud auth application-default login
+```
+
+#### Usage Examples
+
+```bash
+# Grant access to a specific user
+python bigquery_dataset_access_manager.py \
+    --project-id your-project-id \
+    --action grant \
+    --dataset-id user_dataset \
+    --user-email john.doe@example.com \
+    --role OWNER
+
+# Create isolated dataset for a user
+python bigquery_dataset_access_manager.py \
+    --project-id your-project-id \
+    --action create-user-dataset \
+    --user-email jane.smith@example.com
+
+# Remove public access from a dataset
+python bigquery_dataset_access_manager.py \
+    --project-id your-project-id \
+    --action remove-public \
+    --dataset-id shared_dataset
+
+# Audit all dataset access
+python bigquery_dataset_access_manager.py \
+    --project-id your-project-id \
+    --action audit
+
+# Bulk grant access using config file
+python bigquery_dataset_access_manager.py \
+    --project-id your-project-id \
+    --action bulk-grant \
+    --config-file permissions.json
+```
+
+#### Bulk Configuration File Format
+
+Create a `permissions.json` file:
+
+```json
+{
+  "dataset_sales": {
+    "users": ["sales_team@example.com", "analyst@example.com"],
+    "groups": ["sales-group@example.com"],
+    "role": "READER"
+  },
+  "dataset_marketing": {
+    "users": ["marketing_lead@example.com"],
+    "groups": ["marketing-group@example.com"],
+    "role": "WRITER"
+  }
+}
+```
+
+### 2. Terraform Configuration (`bigquery_access_terraform/`)
+
+Infrastructure-as-Code approach for managing BigQuery dataset access.
+
+#### Setup
+
+```bash
+cd bigquery_access_terraform
+
+# Initialize Terraform
+terraform init
+
+# Copy and update the example variables file
+cp terraform.tfvars.example terraform.tfvars
+
+# Plan the changes
+terraform plan
+
+# Apply the configuration
+terraform apply
+```
+
+#### Key Features
+
+- Automated creation of user-specific datasets
+- Support for shared datasets with multiple access levels
+- IAM role bindings with conditions
+- Custom IAM roles for fine-grained access control
+- Encryption support with Cloud KMS
+
+### 3. Shell Script (`manage_bigquery_access.sh`)
+
+Interactive and command-line tool for quick dataset access management.
+
+#### Usage
+
+```bash
+# Make the script executable
+chmod +x manage_bigquery_access.sh
+
+# Set project ID
+export GCP_PROJECT_ID="your-project-id"
+
+# Interactive mode
+./manage_bigquery_access.sh
+
+# Command-line mode examples
+./manage_bigquery_access.sh --project my-project --list
+./manage_bigquery_access.sh --project my-project --audit
+./manage_bigquery_access.sh --project my-project --grant dataset1 user@example.com READER
+./manage_bigquery_access.sh --project my-project --create-user-dataset john.doe@example.com
+./manage_bigquery_access.sh --project my-project --remove-public
+```
+
+## Best Practices for Dataset Access Control
+
+### 1. Dataset Naming Conventions
+
+Use clear naming conventions to identify dataset ownership:
+
+```
+user_<username>_<purpose>     # For individual users
+team_<teamname>_<purpose>     # For team datasets
+shared_<purpose>              # For shared resources
+temp_<purpose>_<date>         # For temporary datasets
+```
+
+### 2. Access Control Hierarchy
+
+Implement a clear access hierarchy:
+
+1. **Dataset Owner**: Full control (OWNER role)
+2. **Data Editor**: Can modify data (WRITER role)
+3. **Data Viewer**: Read-only access (READER role)
+4. **No Access**: Cannot see or access the dataset
+
+### 3. Security Best Practices
+
+#### Remove Default Access
+
+By default, datasets may have broader access than needed. Always:
+
+```python
+# Remove public access
+manager.remove_public_access(dataset_id)
+
+# Remove all authenticated users access
+# Check and remove special groups like "allAuthenticatedUsers"
+```
+
+#### Use Service Accounts
+
+For automated processes, use service accounts with minimal required permissions:
+
+```bash
+# Create service account
+gcloud iam service-accounts create bq-reader \
+    --display-name="BigQuery Reader Service Account"
+
+# Grant specific dataset access
+python bigquery_dataset_access_manager.py \
+    --project-id your-project \
+    --action grant \
+    --dataset-id my_dataset \
+    --user-email bq-reader@your-project.iam.gserviceaccount.com \
+    --role READER
+```
+
+#### Implement Audit Logging
+
+Regular auditing helps identify security issues:
+
+```bash
+# Run regular audits
+./manage_bigquery_access.sh --audit > audit_report_$(date +%Y%m%d).txt
+
+# Check for public access
+python bigquery_dataset_access_manager.py \
+    --project-id your-project \
+    --action audit | grep -i "public\|allUsers\|allAuthenticatedUsers"
+```
+
+### 4. User Isolation Strategies
+
+#### Strategy 1: Separate Datasets per User
+
+Create isolated datasets for each user:
+
+```python
+# Each user gets their own dataset
+users = ["alice@example.com", "bob@example.com", "charlie@example.com"]
+for user in users:
+    manager.setup_user_dataset(user)
+```
+
+#### Strategy 2: Authorized Views
+
+Create views that filter data based on user identity:
+
+```sql
+-- Create a view that shows only user's data
+CREATE OR REPLACE VIEW `project.user_views.my_data` AS
+SELECT * 
+FROM `project.all_data.main_table`
+WHERE user_email = SESSION_USER();
+```
+
+#### Strategy 3: Row-Level Security
+
+Use BigQuery's row-level security policies:
+
+```sql
+-- Create row access policy
+CREATE ROW ACCESS POLICY user_filter
+ON `project.dataset.table`
+GRANT TO ("user:alice@example.com")
+FILTER USING (user_column = "alice");
+```
+
+### 5. Group-Based Access Management
+
+Use Google Groups for easier management:
+
+```bash
+# Create groups for different access levels
+# In Google Admin Console, create:
+# - data-owners@yourdomain.com
+# - data-editors@yourdomain.com  
+# - data-viewers@yourdomain.com
+
+# Grant access to groups instead of individuals
+python bigquery_dataset_access_manager.py \
+    --project-id your-project \
+    --action grant \
+    --dataset-id shared_dataset \
+    --group-email data-viewers@yourdomain.com \
+    --role READER
+```
+
+### 6. Time-Based Access Control
+
+Implement temporary access using IAM conditions:
+
+```terraform
+resource "google_bigquery_dataset_iam_binding" "temporary_access" {
+  dataset_id = "temporary_dataset"
+  role      = "roles/bigquery.dataViewer"
+  members   = ["user:contractor@example.com"]
+
+  condition {
+    title       = "Temporary Access"
+    description = "Access expires after 30 days"
+    expression  = "request.time < timestamp('2024-02-01T00:00:00Z')"
+  }
+}
+```
+
+### 7. Monitoring and Alerting
+
+Set up monitoring for access changes:
+
+```bash
+# Create log sink for BigQuery access logs
+gcloud logging sinks create bigquery-access-sink \
+    bigquery.googleapis.com/projects/your-project/datasets/audit_logs \
+    --log-filter='resource.type="bigquery_dataset" AND 
+                  protoPayload.methodName=~"setIamPolicy|update"'
+
+# Set up alerting for unauthorized access attempts
+gcloud alpha monitoring policies create \
+    --notification-channels=CHANNEL_ID \
+    --display-name="Unauthorized BigQuery Access" \
+    --condition-display-name="Failed access attempts" \
+    --condition-expression='resource.type="bigquery_dataset" AND 
+                           severity="ERROR" AND 
+                           protoPayload.status.code=7'
+```
+
+## Common Use Cases
+
+### 1. Multi-Tenant SaaS Application
+
+Each customer gets their own dataset:
+
+```python
+def onboard_new_customer(customer_id, admin_email):
+    dataset_id = f"customer_{customer_id}"
+    
+    # Create isolated dataset
+    manager.setup_user_dataset(admin_email, dataset_prefix=f"customer_{customer_id}")
+    
+    # Remove any public access
+    manager.remove_public_access(dataset_id)
+    
+    # Grant access to customer's team
+    for user in get_customer_users(customer_id):
+        manager.grant_dataset_access(dataset_id, user, "READER")
+```
+
+### 2. Department-Based Access
+
+Different departments with isolated data:
+
+```python
+departments = {
+    "finance": ["cfo@company.com", "accountant@company.com"],
+    "sales": ["sales_director@company.com", "sales_team@company.com"],
+    "engineering": ["cto@company.com", "dev_team@company.com"]
+}
+
+for dept, users in departments.items():
+    dataset_id = f"dept_{dept}"
+    # Create dataset
+    create_dataset(dataset_id)
+    
+    # Grant access to department users
+    for user in users:
+        role = "OWNER" if "director" in user or "cfo" in user or "cto" in user else "READER"
+        manager.grant_dataset_access(dataset_id, user, role)
+```
+
+### 3. Project-Based Access
+
+Temporary project teams with time-limited access:
+
+```python
+def setup_project_dataset(project_name, team_members, end_date):
+    dataset_id = f"project_{project_name}"
+    
+    # Create dataset
+    create_dataset(dataset_id)
+    
+    # Grant temporary access to team members
+    for member in team_members:
+        grant_temporary_access(dataset_id, member, end_date)
+```
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+#### 1. "Permission Denied" Errors
+
+```bash
+# Check current permissions
+bq show --format=prettyjson project:dataset | jq '.access'
+
+# Verify user authentication
+gcloud auth list
+
+# Check project-level IAM roles
+gcloud projects get-iam-policy your-project
+```
+
+#### 2. Users Can Still See Other Datasets
+
+Users need at least `bigquery.datasets.get` permission to run queries. To completely hide datasets:
+
+1. Remove project-level BigQuery roles
+2. Grant dataset-specific access only
+3. Use authorized views for cross-dataset queries
+
+```bash
+# Remove project-level viewer role
+gcloud projects remove-iam-policy-binding your-project \
+    --member="user:user@example.com" \
+    --role="roles/bigquery.dataViewer"
+
+# Grant only specific dataset access
+python bigquery_dataset_access_manager.py \
+    --project-id your-project \
+    --action grant \
+    --dataset-id user_dataset \
+    --user-email user@example.com \
+    --role READER
+```
+
+#### 3. Service Account Access Issues
+
+```bash
+# Create and download service account key
+gcloud iam service-accounts keys create key.json \
+    --iam-account=sa@project.iam.gserviceaccount.com
+
+# Set environment variable
+export GOOGLE_APPLICATION_CREDENTIALS="path/to/key.json"
+
+# Test access
+bq ls --project_id=your-project
+```
+
+## Requirements
+
+### Python Script Requirements
+
+```txt
+google-cloud-bigquery>=3.0.0
+google-auth>=2.0.0
+```
+
+### Terraform Requirements
+
+```hcl
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+```
+
+### Shell Script Requirements
+
+- `gcloud` CLI installed and configured
+- `bq` command-line tool installed
+- `jq` for JSON processing (optional but recommended)
+
+## Conclusion
+
+By implementing these access control strategies, you can effectively restrict BigQuery dataset access so that users can only see and access their own datasets. Choose the approach that best fits your organization's needs:
+
+- Use the **Python script** for programmatic access management
+- Use **Terraform** for infrastructure-as-code and version-controlled configurations
+- Use the **Shell script** for quick, interactive management tasks
+
+Remember to regularly audit access permissions and follow the security best practices outlined in this guide.

--- a/bigquery_access_terraform/main.tf
+++ b/bigquery_access_terraform/main.tf
@@ -1,0 +1,238 @@
+/**
+ * Terraform configuration for managing BigQuery dataset access control
+ * This configuration helps create isolated datasets with user-specific permissions
+ */
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Configure the Google Cloud Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Variables
+variable "project_id" {
+  description = "Google Cloud Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "Default region for resources"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "dataset_location" {
+  description = "Location for BigQuery datasets"
+  type        = string
+  default     = "US"
+}
+
+variable "user_datasets" {
+  description = "Map of users and their dataset configurations"
+  type = map(object({
+    user_email  = string
+    role        = string
+    description = string
+  }))
+  default = {}
+}
+
+variable "shared_datasets" {
+  description = "Datasets with multiple user access"
+  type = map(object({
+    description = string
+    users = list(object({
+      email = string
+      role  = string
+    }))
+    groups = list(object({
+      email = string
+      role  = string
+    }))
+    service_accounts = list(object({
+      email = string
+      role  = string
+    }))
+  }))
+  default = {}
+}
+
+# Create user-specific datasets with restricted access
+resource "google_bigquery_dataset" "user_datasets" {
+  for_each = var.user_datasets
+
+  dataset_id  = each.key
+  project     = var.project_id
+  location    = var.dataset_location
+  description = each.value.description
+
+  # Set default table expiration (optional)
+  default_table_expiration_ms = 2592000000 # 30 days in milliseconds
+
+  # Default encryption configuration
+  default_encryption_configuration {
+    kms_key_name = var.kms_key_name
+  }
+
+  # Access control - only specific user has access
+  access {
+    role          = each.value.role
+    user_by_email = each.value.user_email
+  }
+
+  # Project owners always have access
+  access {
+    role           = "OWNER"
+    special_group  = "projectOwners"
+  }
+
+  labels = {
+    environment = "production"
+    owner       = replace(each.value.user_email, "@", "_at_")
+    managed_by  = "terraform"
+  }
+}
+
+# Create shared datasets with multiple user access
+resource "google_bigquery_dataset" "shared_datasets" {
+  for_each = var.shared_datasets
+
+  dataset_id  = each.key
+  project     = var.project_id
+  location    = var.dataset_location
+  description = each.value.description
+
+  # Default table expiration
+  default_table_expiration_ms = 2592000000
+
+  # Default encryption
+  default_encryption_configuration {
+    kms_key_name = var.kms_key_name
+  }
+
+  # Dynamic access blocks for users
+  dynamic "access" {
+    for_each = each.value.users
+    content {
+      role          = access.value.role
+      user_by_email = access.value.email
+    }
+  }
+
+  # Dynamic access blocks for groups
+  dynamic "access" {
+    for_each = each.value.groups
+    content {
+      role           = access.value.role
+      group_by_email = access.value.email
+    }
+  }
+
+  # Dynamic access blocks for service accounts
+  dynamic "access" {
+    for_each = each.value.service_accounts
+    content {
+      role          = access.value.role
+      user_by_email = access.value.email
+    }
+  }
+
+  # Project owners always have access
+  access {
+    role          = "OWNER"
+    special_group = "projectOwners"
+  }
+
+  labels = {
+    environment = "production"
+    type        = "shared"
+    managed_by  = "terraform"
+  }
+}
+
+# Create authorized views for cross-dataset access
+resource "google_bigquery_dataset" "authorized_views_dataset" {
+  dataset_id  = "authorized_views"
+  project     = var.project_id
+  location    = var.dataset_location
+  description = "Dataset containing authorized views for controlled data access"
+
+  # This dataset can be accessed by all authenticated users
+  # but the views inside control what data they can see
+  access {
+    role          = "READER"
+    special_group = "allAuthenticatedUsers"
+  }
+
+  access {
+    role          = "OWNER"
+    special_group = "projectOwners"
+  }
+
+  labels = {
+    environment = "production"
+    type        = "views"
+    managed_by  = "terraform"
+  }
+}
+
+# IAM bindings for dataset-level permissions
+resource "google_bigquery_dataset_iam_binding" "dataset_viewers" {
+  for_each = var.user_datasets
+
+  dataset_id = google_bigquery_dataset.user_datasets[each.key].dataset_id
+  role       = "roles/bigquery.dataViewer"
+
+  members = [
+    "user:${each.value.user_email}"
+  ]
+}
+
+resource "google_bigquery_dataset_iam_binding" "dataset_editors" {
+  for_each = var.user_datasets
+
+  dataset_id = google_bigquery_dataset.user_datasets[each.key].dataset_id
+  role       = "roles/bigquery.dataEditor"
+
+  members = [
+    "user:${each.value.user_email}"
+  ]
+
+  condition {
+    title       = "Restrict to business hours"
+    description = "Only allow edits during business hours"
+    expression  = "request.time.getHours(\"America/New_York\") >= 9 && request.time.getHours(\"America/New_York\") <= 17"
+  }
+}
+
+# Custom IAM role for limited dataset access
+resource "google_project_iam_custom_role" "bigquery_limited_viewer" {
+  role_id     = "bigqueryLimitedViewer"
+  title       = "BigQuery Limited Viewer"
+  description = "Can only view specific datasets and run queries"
+  
+  permissions = [
+    "bigquery.datasets.get",
+    "bigquery.tables.get",
+    "bigquery.tables.getData",
+    "bigquery.tables.list",
+    "bigquery.jobs.create",
+  ]
+}
+
+# Variables for encryption
+variable "kms_key_name" {
+  description = "KMS key name for dataset encryption"
+  type        = string
+  default     = ""
+}

--- a/bigquery_access_terraform/outputs.tf
+++ b/bigquery_access_terraform/outputs.tf
@@ -1,0 +1,41 @@
+# Outputs for BigQuery dataset access configuration
+
+output "user_dataset_ids" {
+  description = "IDs of created user-specific datasets"
+  value = {
+    for k, v in google_bigquery_dataset.user_datasets : k => v.dataset_id
+  }
+}
+
+output "shared_dataset_ids" {
+  description = "IDs of created shared datasets"
+  value = {
+    for k, v in google_bigquery_dataset.shared_datasets : k => v.dataset_id
+  }
+}
+
+output "user_dataset_self_links" {
+  description = "Self links of created user datasets"
+  value = {
+    for k, v in google_bigquery_dataset.user_datasets : k => v.self_link
+  }
+}
+
+output "dataset_access_summary" {
+  description = "Summary of dataset access configurations"
+  value = {
+    user_datasets = {
+      for k, v in var.user_datasets : k => {
+        user  = v.user_email
+        role  = v.role
+      }
+    }
+    shared_datasets = {
+      for k, v in var.shared_datasets : k => {
+        user_count           = length(v.users)
+        group_count          = length(v.groups)
+        service_account_count = length(v.service_accounts)
+      }
+    }
+  }
+}

--- a/bigquery_access_terraform/terraform.tfvars.example
+++ b/bigquery_access_terraform/terraform.tfvars.example
@@ -1,0 +1,76 @@
+# Example Terraform variables file for BigQuery dataset access control
+# Copy this to terraform.tfvars and update with your values
+
+project_id = "your-gcp-project-id"
+region     = "us-central1"
+dataset_location = "US"
+
+# User-specific datasets - each user can only access their own dataset
+user_datasets = {
+  "dataset_john_doe" = {
+    user_email  = "john.doe@example.com"
+    role        = "OWNER"
+    description = "Personal dataset for John Doe"
+  }
+  
+  "dataset_jane_smith" = {
+    user_email  = "jane.smith@example.com"
+    role        = "OWNER"
+    description = "Personal dataset for Jane Smith"
+  }
+  
+  "dataset_bob_wilson" = {
+    user_email  = "bob.wilson@example.com"
+    role        = "OWNER"
+    description = "Personal dataset for Bob Wilson"
+  }
+}
+
+# Shared datasets with controlled access
+shared_datasets = {
+  "marketing_data" = {
+    description = "Marketing team shared dataset"
+    users = [
+      {
+        email = "marketing_lead@example.com"
+        role  = "OWNER"
+      },
+      {
+        email = "analyst1@example.com"
+        role  = "WRITER"
+      }
+    ]
+    groups = [
+      {
+        email = "marketing-team@example.com"
+        role  = "READER"
+      }
+    ]
+    service_accounts = [
+      {
+        email = "marketing-etl@project.iam.gserviceaccount.com"
+        role  = "WRITER"
+      }
+    ]
+  }
+  
+  "sales_data" = {
+    description = "Sales team shared dataset"
+    users = [
+      {
+        email = "sales_lead@example.com"
+        role  = "OWNER"
+      }
+    ]
+    groups = [
+      {
+        email = "sales-team@example.com"
+        role  = "READER"
+      }
+    ]
+    service_accounts = []
+  }
+}
+
+# Optional: KMS key for encryption
+# kms_key_name = "projects/your-project/locations/us/keyRings/your-keyring/cryptoKeys/your-key"

--- a/bigquery_dataset_access_manager.py
+++ b/bigquery_dataset_access_manager.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""
+BigQuery Dataset Access Manager
+This script helps manage dataset-level permissions in Google BigQuery,
+allowing you to restrict access so users can only see their own datasets.
+"""
+
+import argparse
+import json
+from typing import List, Dict, Optional
+from google.cloud import bigquery
+from google.cloud.exceptions import GoogleCloudError
+from google.api_core import exceptions
+
+
+class BigQueryAccessManager:
+    """Manages access control for BigQuery datasets."""
+    
+    def __init__(self, project_id: str):
+        """
+        Initialize the BigQuery Access Manager.
+        
+        Args:
+            project_id: Google Cloud Project ID
+        """
+        self.project_id = project_id
+        self.client = bigquery.Client(project=project_id)
+    
+    def list_datasets(self) -> List[str]:
+        """
+        List all datasets in the project.
+        
+        Returns:
+            List of dataset IDs
+        """
+        datasets = list(self.client.list_datasets())
+        return [dataset.dataset_id for dataset in datasets]
+    
+    def get_dataset_access(self, dataset_id: str) -> List[Dict]:
+        """
+        Get current access control list for a dataset.
+        
+        Args:
+            dataset_id: The dataset ID
+            
+        Returns:
+            List of access entries
+        """
+        dataset = self.client.get_dataset(dataset_id)
+        access_entries = []
+        
+        for entry in dataset.access_entries:
+            access_entry = {
+                'role': entry.role,
+                'entity_type': entry.entity_type,
+                'entity_id': entry.entity_id
+            }
+            access_entries.append(access_entry)
+        
+        return access_entries
+    
+    def grant_dataset_access(self, dataset_id: str, user_email: str, 
+                           role: str = "READER") -> None:
+        """
+        Grant access to a specific user for a dataset.
+        
+        Args:
+            dataset_id: The dataset ID
+            user_email: Email of the user to grant access
+            role: Role to grant (READER, WRITER, OWNER)
+        """
+        dataset = self.client.get_dataset(dataset_id)
+        
+        # Create new access entry
+        entry = bigquery.AccessEntry(
+            role=role,
+            entity_type="userByEmail",
+            entity_id=user_email,
+        )
+        
+        # Check if entry already exists
+        entries = list(dataset.access_entries)
+        for existing_entry in entries:
+            if (existing_entry.entity_type == "userByEmail" and 
+                existing_entry.entity_id == user_email):
+                print(f"User {user_email} already has access to {dataset_id}")
+                return
+        
+        # Add new entry
+        entries.append(entry)
+        dataset.access_entries = entries
+        
+        # Update dataset
+        dataset = self.client.update_dataset(dataset, ["access_entries"])
+        print(f"Granted {role} access to {user_email} for dataset {dataset_id}")
+    
+    def revoke_dataset_access(self, dataset_id: str, user_email: str) -> None:
+        """
+        Revoke access from a specific user for a dataset.
+        
+        Args:
+            dataset_id: The dataset ID
+            user_email: Email of the user to revoke access
+        """
+        dataset = self.client.get_dataset(dataset_id)
+        
+        # Filter out the user's access
+        entries = []
+        removed = False
+        
+        for entry in dataset.access_entries:
+            if not (entry.entity_type == "userByEmail" and 
+                   entry.entity_id == user_email):
+                entries.append(entry)
+            else:
+                removed = True
+        
+        if removed:
+            dataset.access_entries = entries
+            dataset = self.client.update_dataset(dataset, ["access_entries"])
+            print(f"Revoked access from {user_email} for dataset {dataset_id}")
+        else:
+            print(f"User {user_email} doesn't have access to {dataset_id}")
+    
+    def grant_group_access(self, dataset_id: str, group_email: str, 
+                          role: str = "READER") -> None:
+        """
+        Grant access to a Google Group for a dataset.
+        
+        Args:
+            dataset_id: The dataset ID
+            group_email: Email of the group to grant access
+            role: Role to grant (READER, WRITER, OWNER)
+        """
+        dataset = self.client.get_dataset(dataset_id)
+        
+        entry = bigquery.AccessEntry(
+            role=role,
+            entity_type="groupByEmail",
+            entity_id=group_email,
+        )
+        
+        entries = list(dataset.access_entries)
+        entries.append(entry)
+        dataset.access_entries = entries
+        
+        dataset = self.client.update_dataset(dataset, ["access_entries"])
+        print(f"Granted {role} access to group {group_email} for dataset {dataset_id}")
+    
+    def grant_service_account_access(self, dataset_id: str, 
+                                    service_account_email: str, 
+                                    role: str = "READER") -> None:
+        """
+        Grant access to a service account for a dataset.
+        
+        Args:
+            dataset_id: The dataset ID
+            service_account_email: Email of the service account
+            role: Role to grant (READER, WRITER, OWNER)
+        """
+        dataset = self.client.get_dataset(dataset_id)
+        
+        entry = bigquery.AccessEntry(
+            role=role,
+            entity_type="userByEmail",
+            entity_id=service_account_email,
+        )
+        
+        entries = list(dataset.access_entries)
+        entries.append(entry)
+        dataset.access_entries = entries
+        
+        dataset = self.client.update_dataset(dataset, ["access_entries"])
+        print(f"Granted {role} access to service account {service_account_email} for dataset {dataset_id}")
+    
+    def setup_user_dataset(self, user_email: str, dataset_prefix: str = None) -> str:
+        """
+        Create a dataset for a specific user with restricted access.
+        
+        Args:
+            user_email: Email of the user
+            dataset_prefix: Optional prefix for dataset naming
+            
+        Returns:
+            Created dataset ID
+        """
+        # Generate dataset ID from user email
+        user_part = user_email.split('@')[0].replace('.', '_').replace('-', '_')
+        
+        if dataset_prefix:
+            dataset_id = f"{dataset_prefix}_{user_part}"
+        else:
+            dataset_id = f"user_{user_part}"
+        
+        # Create dataset
+        dataset = bigquery.Dataset(f"{self.project_id}.{dataset_id}")
+        dataset.location = "US"  # Change as needed
+        dataset.description = f"Dataset for user: {user_email}"
+        
+        # Set access controls - only the user and project owners
+        access_entries = [
+            bigquery.AccessEntry(
+                role="OWNER",
+                entity_type="userByEmail",
+                entity_id=user_email,
+            )
+        ]
+        dataset.access_entries = access_entries
+        
+        try:
+            dataset = self.client.create_dataset(dataset)
+            print(f"Created dataset {dataset_id} for user {user_email}")
+            return dataset_id
+        except exceptions.Conflict:
+            print(f"Dataset {dataset_id} already exists")
+            # Update access if dataset exists
+            self.grant_dataset_access(dataset_id, user_email, "OWNER")
+            return dataset_id
+    
+    def remove_public_access(self, dataset_id: str) -> None:
+        """
+        Remove all public and all authenticated users access from a dataset.
+        
+        Args:
+            dataset_id: The dataset ID
+        """
+        dataset = self.client.get_dataset(dataset_id)
+        
+        # Filter out public access entries
+        entries = []
+        for entry in dataset.access_entries:
+            if entry.entity_type not in ["specialGroup", "allUsers", 
+                                        "allAuthenticatedUsers"]:
+                entries.append(entry)
+        
+        dataset.access_entries = entries
+        dataset = self.client.update_dataset(dataset, ["access_entries"])
+        print(f"Removed public access from dataset {dataset_id}")
+    
+    def bulk_grant_access(self, permissions_config: Dict) -> None:
+        """
+        Bulk grant access based on a configuration dictionary.
+        
+        Args:
+            permissions_config: Dictionary with dataset and user mappings
+            
+        Example config:
+        {
+            "dataset1": {
+                "users": ["user1@example.com", "user2@example.com"],
+                "groups": ["group1@example.com"],
+                "role": "READER"
+            }
+        }
+        """
+        for dataset_id, config in permissions_config.items():
+            role = config.get('role', 'READER')
+            
+            # Grant access to users
+            for user in config.get('users', []):
+                try:
+                    self.grant_dataset_access(dataset_id, user, role)
+                except Exception as e:
+                    print(f"Error granting access to {user} for {dataset_id}: {e}")
+            
+            # Grant access to groups
+            for group in config.get('groups', []):
+                try:
+                    self.grant_group_access(dataset_id, group, role)
+                except Exception as e:
+                    print(f"Error granting access to group {group} for {dataset_id}: {e}")
+    
+    def audit_dataset_access(self) -> Dict:
+        """
+        Audit all dataset access in the project.
+        
+        Returns:
+            Dictionary with dataset access information
+        """
+        audit_report = {}
+        
+        for dataset_id in self.list_datasets():
+            try:
+                access_entries = self.get_dataset_access(dataset_id)
+                audit_report[dataset_id] = {
+                    'access_count': len(access_entries),
+                    'entries': access_entries
+                }
+            except Exception as e:
+                audit_report[dataset_id] = {'error': str(e)}
+        
+        return audit_report
+    
+    def create_isolated_datasets(self, users: List[str]) -> None:
+        """
+        Create isolated datasets for a list of users.
+        
+        Args:
+            users: List of user emails
+        """
+        for user_email in users:
+            try:
+                dataset_id = self.setup_user_dataset(user_email)
+                self.remove_public_access(dataset_id)
+            except Exception as e:
+                print(f"Error creating dataset for {user_email}: {e}")
+
+
+def main():
+    """Main function to handle command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description='Manage BigQuery dataset access control'
+    )
+    parser.add_argument('--project-id', required=True, 
+                       help='Google Cloud Project ID')
+    parser.add_argument('--action', required=True,
+                       choices=['grant', 'revoke', 'list', 'audit', 
+                               'create-user-dataset', 'remove-public',
+                               'bulk-grant'],
+                       help='Action to perform')
+    parser.add_argument('--dataset-id', help='Dataset ID')
+    parser.add_argument('--user-email', help='User email address')
+    parser.add_argument('--group-email', help='Group email address')
+    parser.add_argument('--role', default='READER',
+                       choices=['READER', 'WRITER', 'OWNER'],
+                       help='Role to grant')
+    parser.add_argument('--config-file', help='JSON config file for bulk operations')
+    parser.add_argument('--users-file', help='File with list of user emails')
+    
+    args = parser.parse_args()
+    
+    # Initialize manager
+    manager = BigQueryAccessManager(args.project_id)
+    
+    # Perform action
+    if args.action == 'grant':
+        if args.user_email and args.dataset_id:
+            manager.grant_dataset_access(args.dataset_id, args.user_email, 
+                                        args.role)
+        elif args.group_email and args.dataset_id:
+            manager.grant_group_access(args.dataset_id, args.group_email, 
+                                      args.role)
+        else:
+            print("Error: Specify --dataset-id and either --user-email or --group-email")
+    
+    elif args.action == 'revoke':
+        if args.user_email and args.dataset_id:
+            manager.revoke_dataset_access(args.dataset_id, args.user_email)
+        else:
+            print("Error: Specify --dataset-id and --user-email")
+    
+    elif args.action == 'list':
+        if args.dataset_id:
+            access_list = manager.get_dataset_access(args.dataset_id)
+            print(json.dumps(access_list, indent=2))
+        else:
+            datasets = manager.list_datasets()
+            print("Datasets in project:")
+            for dataset in datasets:
+                print(f"  - {dataset}")
+    
+    elif args.action == 'audit':
+        audit_report = manager.audit_dataset_access()
+        print(json.dumps(audit_report, indent=2))
+    
+    elif args.action == 'create-user-dataset':
+        if args.user_email:
+            manager.setup_user_dataset(args.user_email)
+        elif args.users_file:
+            with open(args.users_file, 'r') as f:
+                users = [line.strip() for line in f if line.strip()]
+            manager.create_isolated_datasets(users)
+        else:
+            print("Error: Specify --user-email or --users-file")
+    
+    elif args.action == 'remove-public':
+        if args.dataset_id:
+            manager.remove_public_access(args.dataset_id)
+        else:
+            # Remove public access from all datasets
+            for dataset_id in manager.list_datasets():
+                try:
+                    manager.remove_public_access(dataset_id)
+                except Exception as e:
+                    print(f"Error removing public access from {dataset_id}: {e}")
+    
+    elif args.action == 'bulk-grant':
+        if args.config_file:
+            with open(args.config_file, 'r') as f:
+                config = json.load(f)
+            manager.bulk_grant_access(config)
+        else:
+            print("Error: Specify --config-file for bulk operations")
+
+
+if __name__ == "__main__":
+    main()

--- a/example_permissions.json
+++ b/example_permissions.json
@@ -1,0 +1,53 @@
+{
+  "sales_dataset": {
+    "users": [
+      "sales_manager@example.com",
+      "sales_analyst1@example.com",
+      "sales_analyst2@example.com"
+    ],
+    "groups": [
+      "sales-team@example.com"
+    ],
+    "role": "READER"
+  },
+  "marketing_dataset": {
+    "users": [
+      "marketing_director@example.com",
+      "marketing_analyst@example.com"
+    ],
+    "groups": [
+      "marketing-team@example.com"
+    ],
+    "role": "WRITER"
+  },
+  "finance_dataset": {
+    "users": [
+      "cfo@example.com",
+      "finance_manager@example.com"
+    ],
+    "groups": [
+      "finance-team@example.com"
+    ],
+    "role": "READER"
+  },
+  "hr_dataset": {
+    "users": [
+      "hr_director@example.com"
+    ],
+    "groups": [
+      "hr-team@example.com"
+    ],
+    "role": "OWNER"
+  },
+  "engineering_dataset": {
+    "users": [
+      "cto@example.com",
+      "lead_engineer@example.com"
+    ],
+    "groups": [
+      "engineering-team@example.com",
+      "devops-team@example.com"
+    ],
+    "role": "WRITER"
+  }
+}

--- a/example_users.txt
+++ b/example_users.txt
@@ -1,0 +1,10 @@
+# Example users file for bulk dataset creation
+# One email per line
+john.doe@example.com
+jane.smith@example.com
+bob.wilson@example.com
+alice.johnson@example.com
+david.brown@example.com
+sarah.davis@example.com
+michael.garcia@example.com
+emma.martinez@example.com

--- a/manage_bigquery_access.sh
+++ b/manage_bigquery_access.sh
@@ -1,0 +1,431 @@
+#!/bin/bash
+
+################################################################################
+# BigQuery Dataset Access Management Script
+# This script provides utilities to manage dataset-level access in BigQuery
+################################################################################
+
+set -euo pipefail
+
+# Configuration
+PROJECT_ID="${GCP_PROJECT_ID:-}"
+DATASET_LOCATION="${DATASET_LOCATION:-US}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Functions
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check prerequisites
+check_prerequisites() {
+    if ! command -v gcloud &> /dev/null; then
+        log_error "gcloud CLI is not installed. Please install it first."
+        exit 1
+    fi
+    
+    if ! command -v bq &> /dev/null; then
+        log_error "bq CLI is not installed. Please install it first."
+        exit 1
+    fi
+    
+    if [ -z "$PROJECT_ID" ]; then
+        log_error "PROJECT_ID is not set. Set GCP_PROJECT_ID environment variable or use --project flag"
+        exit 1
+    fi
+    
+    # Check authentication
+    if ! gcloud auth application-default print-access-token &> /dev/null; then
+        log_warn "Not authenticated. Running gcloud auth login..."
+        gcloud auth application-default login
+    fi
+    
+    # Set default project
+    gcloud config set project "$PROJECT_ID"
+}
+
+# List all datasets in the project
+list_datasets() {
+    log_info "Listing datasets in project: $PROJECT_ID"
+    bq ls --project_id="$PROJECT_ID" --format=prettyjson | jq -r '.[] | .datasetReference.datasetId'
+}
+
+# Get current access for a dataset
+get_dataset_access() {
+    local dataset_id=$1
+    log_info "Getting access list for dataset: $dataset_id"
+    bq show --format=prettyjson "$PROJECT_ID:$dataset_id" | jq '.access'
+}
+
+# Grant user access to a dataset
+grant_user_access() {
+    local dataset_id=$1
+    local user_email=$2
+    local role=${3:-READER}
+    
+    log_info "Granting $role access to $user_email for dataset $dataset_id"
+    
+    # Get current access
+    current_access=$(bq show --format=json "$PROJECT_ID:$dataset_id" | jq '.access')
+    
+    # Check if user already has access
+    if echo "$current_access" | jq -e ".[] | select(.userByEmail == \"$user_email\")" > /dev/null; then
+        log_warn "User $user_email already has access to $dataset_id"
+        return 0
+    fi
+    
+    # Add new access entry
+    new_entry="{\"role\": \"$role\", \"userByEmail\": \"$user_email\"}"
+    updated_access=$(echo "$current_access" | jq ". + [$new_entry]")
+    
+    # Update dataset with new access
+    echo "$updated_access" > /tmp/access.json
+    bq update --source /tmp/access.json "$PROJECT_ID:$dataset_id"
+    rm /tmp/access.json
+    
+    log_info "Successfully granted access"
+}
+
+# Revoke user access from a dataset
+revoke_user_access() {
+    local dataset_id=$1
+    local user_email=$2
+    
+    log_info "Revoking access from $user_email for dataset $dataset_id"
+    
+    # Get current access
+    current_access=$(bq show --format=json "$PROJECT_ID:$dataset_id" | jq '.access')
+    
+    # Remove user access
+    updated_access=$(echo "$current_access" | jq "map(select(.userByEmail != \"$user_email\"))")
+    
+    # Update dataset with new access
+    echo "$updated_access" > /tmp/access.json
+    bq update --source /tmp/access.json "$PROJECT_ID:$dataset_id"
+    rm /tmp/access.json
+    
+    log_info "Successfully revoked access"
+}
+
+# Create a dataset for a specific user
+create_user_dataset() {
+    local user_email=$1
+    local dataset_prefix=${2:-user}
+    
+    # Generate dataset ID from email
+    local user_part=$(echo "$user_email" | cut -d@ -f1 | tr '.-' '_')
+    local dataset_id="${dataset_prefix}_${user_part}"
+    
+    log_info "Creating dataset $dataset_id for user $user_email"
+    
+    # Create dataset
+    bq mk --location="$DATASET_LOCATION" \
+        --description="Dataset for user: $user_email" \
+        --project_id="$PROJECT_ID" \
+        "$dataset_id"
+    
+    # Set access - remove all default access and add only the user
+    access_json="[
+        {\"role\": \"OWNER\", \"userByEmail\": \"$user_email\"},
+        {\"role\": \"OWNER\", \"specialGroup\": \"projectOwners\"}
+    ]"
+    
+    echo "$access_json" > /tmp/access.json
+    bq update --source /tmp/access.json "$PROJECT_ID:$dataset_id"
+    rm /tmp/access.json
+    
+    log_info "Successfully created dataset $dataset_id with exclusive access for $user_email"
+}
+
+# Remove public access from all datasets
+remove_all_public_access() {
+    log_info "Removing public access from all datasets in project $PROJECT_ID"
+    
+    for dataset_id in $(list_datasets); do
+        log_info "Processing dataset: $dataset_id"
+        
+        # Get current access
+        current_access=$(bq show --format=json "$PROJECT_ID:$dataset_id" | jq '.access')
+        
+        # Filter out public access entries
+        updated_access=$(echo "$current_access" | jq 'map(select(
+            .specialGroup != "allUsers" and 
+            .specialGroup != "allAuthenticatedUsers"
+        ))')
+        
+        # Update dataset
+        echo "$updated_access" > /tmp/access.json
+        bq update --source /tmp/access.json "$PROJECT_ID:$dataset_id"
+        
+        log_info "Removed public access from $dataset_id"
+    done
+    
+    rm -f /tmp/access.json
+}
+
+# Bulk create datasets from a file
+bulk_create_user_datasets() {
+    local users_file=$1
+    
+    if [ ! -f "$users_file" ]; then
+        log_error "File $users_file not found"
+        exit 1
+    fi
+    
+    log_info "Creating datasets for users from $users_file"
+    
+    while IFS= read -r user_email; do
+        if [ -n "$user_email" ]; then
+            create_user_dataset "$user_email"
+        fi
+    done < "$users_file"
+}
+
+# Audit all dataset access
+audit_dataset_access() {
+    log_info "Auditing dataset access for project $PROJECT_ID"
+    
+    echo "Dataset Access Audit Report"
+    echo "==========================="
+    echo ""
+    
+    for dataset_id in $(list_datasets); do
+        echo "Dataset: $dataset_id"
+        echo "-------------------"
+        
+        access_list=$(get_dataset_access "$dataset_id")
+        
+        # Count different types of access
+        user_count=$(echo "$access_list" | jq '[.[] | select(.userByEmail)] | length')
+        group_count=$(echo "$access_list" | jq '[.[] | select(.groupByEmail)] | length')
+        special_count=$(echo "$access_list" | jq '[.[] | select(.specialGroup)] | length')
+        view_count=$(echo "$access_list" | jq '[.[] | select(.view)] | length')
+        
+        echo "  Users: $user_count"
+        echo "  Groups: $group_count"
+        echo "  Special Groups: $special_count"
+        echo "  Views: $view_count"
+        
+        # Check for public access
+        if echo "$access_list" | jq -e '.[] | select(.specialGroup == "allUsers" or .specialGroup == "allAuthenticatedUsers")' > /dev/null; then
+            echo "  ⚠️  WARNING: Dataset has public access!"
+        fi
+        
+        echo ""
+    done
+}
+
+# Create authorized view for controlled access
+create_authorized_view() {
+    local source_dataset=$1
+    local source_table=$2
+    local view_dataset=$3
+    local view_name=$4
+    local where_clause=$5
+    
+    log_info "Creating authorized view $view_name in dataset $view_dataset"
+    
+    # Create the view
+    query="SELECT * FROM \`$PROJECT_ID.$source_dataset.$source_table\` WHERE $where_clause"
+    
+    bq mk --use_legacy_sql=false \
+        --view="$query" \
+        --project_id="$PROJECT_ID" \
+        "$view_dataset.$view_name"
+    
+    log_info "Successfully created view $view_name"
+}
+
+# Apply dataset labels for organization
+apply_dataset_labels() {
+    local dataset_id=$1
+    shift
+    local labels="$@"
+    
+    log_info "Applying labels to dataset $dataset_id"
+    
+    label_args=""
+    for label in $labels; do
+        label_args="$label_args --set_label $label"
+    done
+    
+    bq update $label_args "$PROJECT_ID:$dataset_id"
+    
+    log_info "Successfully applied labels"
+}
+
+# Main menu
+show_menu() {
+    echo ""
+    echo "BigQuery Dataset Access Manager"
+    echo "================================"
+    echo "1. List all datasets"
+    echo "2. Show dataset access"
+    echo "3. Grant user access to dataset"
+    echo "4. Revoke user access from dataset"
+    echo "5. Create user-specific dataset"
+    echo "6. Remove public access from all datasets"
+    echo "7. Bulk create user datasets from file"
+    echo "8. Audit all dataset access"
+    echo "9. Exit"
+    echo ""
+    read -p "Select an option: " choice
+}
+
+# Process menu choice
+process_choice() {
+    case $choice in
+        1)
+            list_datasets
+            ;;
+        2)
+            read -p "Enter dataset ID: " dataset_id
+            get_dataset_access "$dataset_id"
+            ;;
+        3)
+            read -p "Enter dataset ID: " dataset_id
+            read -p "Enter user email: " user_email
+            read -p "Enter role (READER/WRITER/OWNER) [READER]: " role
+            role=${role:-READER}
+            grant_user_access "$dataset_id" "$user_email" "$role"
+            ;;
+        4)
+            read -p "Enter dataset ID: " dataset_id
+            read -p "Enter user email: " user_email
+            revoke_user_access "$dataset_id" "$user_email"
+            ;;
+        5)
+            read -p "Enter user email: " user_email
+            read -p "Enter dataset prefix [user]: " prefix
+            prefix=${prefix:-user}
+            create_user_dataset "$user_email" "$prefix"
+            ;;
+        6)
+            read -p "This will remove public access from ALL datasets. Continue? (y/N): " confirm
+            if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+                remove_all_public_access
+            fi
+            ;;
+        7)
+            read -p "Enter path to users file: " users_file
+            bulk_create_user_datasets "$users_file"
+            ;;
+        8)
+            audit_dataset_access
+            ;;
+        9)
+            exit 0
+            ;;
+        *)
+            log_error "Invalid option"
+            ;;
+    esac
+}
+
+# Parse command line arguments
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --project)
+                PROJECT_ID="$2"
+                shift 2
+                ;;
+            --location)
+                DATASET_LOCATION="$2"
+                shift 2
+                ;;
+            --list)
+                check_prerequisites
+                list_datasets
+                exit 0
+                ;;
+            --audit)
+                check_prerequisites
+                audit_dataset_access
+                exit 0
+                ;;
+            --grant)
+                check_prerequisites
+                grant_user_access "$2" "$3" "${4:-READER}"
+                exit 0
+                ;;
+            --revoke)
+                check_prerequisites
+                revoke_user_access "$2" "$3"
+                exit 0
+                ;;
+            --create-user-dataset)
+                check_prerequisites
+                create_user_dataset "$2" "${3:-user}"
+                exit 0
+                ;;
+            --remove-public)
+                check_prerequisites
+                remove_all_public_access
+                exit 0
+                ;;
+            --help)
+                cat << EOF
+Usage: $0 [OPTIONS]
+
+Options:
+    --project PROJECT_ID              Set GCP project ID
+    --location LOCATION               Set dataset location (default: US)
+    --list                           List all datasets
+    --audit                          Audit all dataset access
+    --grant DATASET USER [ROLE]      Grant user access to dataset
+    --revoke DATASET USER            Revoke user access from dataset
+    --create-user-dataset USER       Create dataset for specific user
+    --remove-public                  Remove public access from all datasets
+    --help                           Show this help message
+
+Interactive mode:
+    Run without arguments to enter interactive mode
+
+Examples:
+    $0 --project my-project --list
+    $0 --project my-project --grant my_dataset user@example.com READER
+    $0 --project my-project --create-user-dataset john.doe@example.com
+    $0 --project my-project --audit
+EOF
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+# Main execution
+main() {
+    # If arguments provided, parse them
+    if [ $# -gt 0 ]; then
+        parse_args "$@"
+    fi
+    
+    # Otherwise, run interactive mode
+    check_prerequisites
+    
+    while true; do
+        show_menu
+        process_choice
+    done
+}
+
+# Run main function
+main "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# Requirements for BigQuery Dataset Access Manager
+
+# Google Cloud BigQuery client library
+google-cloud-bigquery>=3.13.0
+
+# Google authentication libraries
+google-auth>=2.23.0
+google-auth-oauthlib>=1.1.0
+google-auth-httplib2>=0.1.1
+
+# Additional utilities (optional but recommended)
+python-dotenv>=1.0.0  # For environment variable management
+click>=8.1.0          # For better CLI interface (optional enhancement)
+tabulate>=0.9.0       # For pretty-printing tables (optional)


### PR DESCRIPTION
Restrict BigQuery dataset view access by providing Python, Terraform, and Shell script solutions.

This PR addresses the need to ensure users can only see and access their own BigQuery datasets within a single Google Cloud project, preventing unauthorized visibility and access to other datasets.

---
<a href="https://cursor.com/background-agent?bcId=bc-e86be8a8-302c-47fc-bc4f-25834f4c62ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e86be8a8-302c-47fc-bc4f-25834f4c62ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

